### PR TITLE
Password guard sign up

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -10,23 +10,33 @@ class SessionController < ApplicationController
 
   #POST /session
   def create
-    if @user = User.find_by(email: params[:email])
-      authenticate?
+    if valid_email? && valid_password?
+      session[:current_user_id] = @user.id
+      redirect_to user_path(@user)
+    elsif !valid_email?
+      invalid_email_alert
     else
-      flash[:alert] = 'Sorry, we do not recognise this email address'
-      render :new
+      invalid_password_alert
     end
   end
-end
 
   private
 
-    def authenticate?
-      if @user && @user.authenticate(params[:password])
-        session[:current_user_id] = @user.id
-        redirect_to user_path(@user)
-      else
-        flash[:alert] = 'Sorry, please check your password and try again'
-        render :new
-      end
+    def valid_email?
+      @user = User.find_by(email: params[:email])
     end
+
+    def valid_password?
+      @user && @user.authenticate(params[:password])
+    end
+
+    def invalid_password_alert
+      flash[:alert] = 'Sorry, please check your password and try again'
+      render :new
+    end
+
+    def invalid_email_alert
+      flash[:alert] = 'Sorry, we do not recognise this email address'
+      render :new
+    end
+end

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -11,18 +11,22 @@ class SessionController < ApplicationController
   #POST /session
   def create
     if @user = User.find_by(email: params[:email])
-      if @user && @user.authenticate(params[:password])
-        session[:current_user_id] = @user.id
-        # p @user.id
-        redirect_to user_path(@user)
-      else
-        flash[:alert] = 'Sorry, please check your password and try again'
-        render :new
-      end
+      authenticate?
     else
       flash[:alert] = 'Sorry, we do not recognise this email address'
       render :new
     end
   end
-
 end
+
+  private
+
+    def authenticate?
+      if @user && @user.authenticate(params[:password])
+        session[:current_user_id] = @user.id
+        redirect_to user_path(@user)
+      else
+        flash[:alert] = 'Sorry, please check your password and try again'
+        render :new
+      end
+    end

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -10,13 +10,19 @@ class SessionController < ApplicationController
 
   #POST /session
   def create
-    @user = User.find_by(email: params[:email])
-    if @user && @user.authenticate(params[:password])
-      session[:current_user_id] = @user.id
-      # p @user.id
-      redirect_to user_path(@user)
+    if @user = User.find_by(email: params[:email])
+      if @user && @user.authenticate(params[:password])
+        session[:current_user_id] = @user.id
+        # p @user.id
+        redirect_to user_path(@user)
+      else
+        flash[:alert] = 'Sorry, please check your password and try again'
+        render :new
+      end
+    else
+      flash[:alert] = 'Sorry, we do not recognise this email address'
+      render :new
     end
-
   end
 
 end

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -12,7 +12,7 @@ class SessionController < ApplicationController
   def create
     if valid_email? && valid_password?
       session[:current_user_id] = @user.id
-      redirect_to user_path(@user)
+      redirect_to user_path(@user), notice: t(".notice")
     elsif !valid_email?
       invalid_email_alert
     else
@@ -31,12 +31,12 @@ class SessionController < ApplicationController
     end
 
     def invalid_password_alert
-      flash[:alert] = 'Sorry, please check your password and try again'
+      flash[:alert] = "The password that you've entered is incorrect."
       render :new
     end
 
     def invalid_email_alert
-      flash[:alert] = 'Sorry, we do not recognise this email address'
+      flash[:alert] = "The email address that you've entered doesn't match an account."
       render :new
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,10 +9,10 @@ class UsersController < ApplicationController
     if @user.save
       session[:current_user_id] = @user.id
       redirect_to user_path(@user)
-      else
-      flash[:alert] = "The password needs to be between 6-10 characters"
+    else
+      # flash[:alert] = "The password needs to be between 6-10 characters"
       render :new
-      end
+    end
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,8 +6,13 @@ class UsersController < ApplicationController
 
   def create
     @user = User.create(user_params)
-    session[:current_user_id] = @user.id
-    redirect_to user_path(@user)
+    if @user.save
+      session[:current_user_id] = @user.id
+      redirect_to user_path(@user)
+      else
+      flash[:alert] = "The password needs to be between 6-10 characters"
+      render :new
+      end
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,10 +8,10 @@ class UsersController < ApplicationController
     @user = User.create(user_params)
     if @user.save
       session[:current_user_id] = @user.id
-      redirect_to user_path(@user)
-      else
+      redirect_to user_path(@user), notice: t(".notice")
+    else
       render :new
-      end
+    end
   end
 
   def show
@@ -23,5 +23,4 @@ class UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:first_name, :last_name, :email, :password)
   end
-
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,6 @@ class UsersController < ApplicationController
       session[:current_user_id] = @user.id
       redirect_to user_path(@user)
       else
-      flash[:alert] = "The password needs to be between 6-10 characters"
       render :new
       end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,11 @@ class User < ApplicationRecord
   # This is a module, part of ActiveModel library
   # full details here: https://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html
   has_secure_password
+
   validates_length_of :password, :in => 6..10, :on => :create
+
+
+
 
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,7 @@ class User < ApplicationRecord
   # This is a module, part of ActiveModel library
   # full details here: https://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html
   has_secure_password
+  validates_length_of :password, :in => 6..10, :on => :create
+
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,12 @@
+require 'uri'
 class User < ApplicationRecord
   # This is a module, part of ActiveModel library
   # full details here: https://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html
   has_secure_password
-
+  EmailRegex = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  
   validates_length_of :password, :in => 6..10, :on => :create
-
-
-
-
-
+  validates_presence_of :first_name
+  validates_presence_of :last_name
+  validates :email, :uniqueness => true, :format => EmailRegex
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,21 @@
+require 'uri'
 class User < ApplicationRecord
   # This is a module, part of ActiveModel library
   # full details here: https://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html
   has_secure_password
+
+
   validates_length_of :password, :in => 6..10, :on => :create
+
+  validates_presence_of :first_name
+  validates_presence_of :last_name
+  validates_presence_of :email
+  validates_uniqueness_of :email
+
+  EmailRegex = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  validates_format_of :email, :with => EmailRegex
+
+
 
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,6 @@ class User < ApplicationRecord
   # full details here: https://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html
   has_secure_password
 
-
   validates_length_of :password, :in => 6..10, :on => :create
 
   validates_presence_of :first_name

--- a/app/views/session/new.html.erb
+++ b/app/views/session/new.html.erb
@@ -7,4 +7,4 @@
 <% end %>
 
 <%= alert ? alert : '' %><br>
-<%= link_to "Sign up for Keeping it rails", "/users/new" %>
+<%= link_to "Sign up for Acebook", "/users/new" %>

--- a/app/views/session/new.html.erb
+++ b/app/views/session/new.html.erb
@@ -3,8 +3,8 @@
   <%= email_field_tag :email, params[:email] %>
   <%= label_tag :password, "Password" %>
   <%= password_field_tag :password, params[:password] %>
-
-<%= submit_tag "Log In" %>
+  <%= submit_tag "Log In" %>
 <% end %>
 
-<%= alert ? alert : '' %>
+<%= alert ? alert : '' %><br>
+<%= link_to "Sign up for Keeping it rails", "/users/new" %>

--- a/app/views/session/new.html.erb
+++ b/app/views/session/new.html.erb
@@ -6,3 +6,7 @@
 
 <%= submit_tag "Log In" %>
 <% end %>
+
+<% if alert %>
+ <%= alert %>
+<% end %>

--- a/app/views/session/new.html.erb
+++ b/app/views/session/new.html.erb
@@ -7,6 +7,4 @@
 <%= submit_tag "Log In" %>
 <% end %>
 
-<% if alert %>
- <%= alert %>
-<% end %>
+<%= alert ? alert : '' %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -10,7 +10,8 @@
   <%= form.submit "Sign Up" %>
 <% end %>
 
-
-<% if alert %>
-<%= alert %>
+<% if @user.errors.any? %>
+  <% @user.errors.messages.each do |message| %>
+  <p><%= message.last.last %></p>
+  <% end %>
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -11,6 +11,4 @@
 <% end %>
 
 
-<% if alert %>
-<%= alert %>
-<% end %>
+<%= link_to "Already a User?", "/session/new" %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -6,9 +6,14 @@
   <%= form.label :email %>
   <%= form.text_field :email %>
   <%= form.label :password %>
-  <%= form.text_field :password %>
+  <%= form.password_field :password %>
   <%= form.submit "Sign Up" %>
 <% end %>
 
-
 <%= link_to "Already a User?", "/session/new" %>
+
+<% if @user.errors.any? %>
+  <% @user.errors.messages.each do |message| %>
+  <p><%= message.last.last %></p>
+  <% end %>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -9,3 +9,8 @@
   <%= form.text_field :password %>
   <%= form.submit "Sign Up" %>
 <% end %>
+
+
+<% if alert %>
+<%= alert %>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -10,7 +10,7 @@
   <%= form.submit "Sign Up" %>
 <% end %>
 
-<%= link_to "Already a User?", "/session/new" %>
+<%= link_to "Already have an Acebook account?", "/session/new" %>
 
 <% if @user.errors.any? %>
   <% @user.errors.messages.each do |message| %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,1 +1,2 @@
+<%= notice ? notice : '' %>
 <p>Welcome <%= @user.first_name %>!</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,23 @@
 #
 # To learn more, please read the Rails Internationalization guide
 # available at http://guides.rubyonrails.org/i18n.html.
-
+#
 en:
-  hello: "Hello world"
+  activerecord:
+    errors:
+      format: "%{message}"
+      models:
+        user:
+          attributes:
+            email:
+              blank: "Please enter an email address"
+              taken: "This email address has already been used"
+              invalid: "Please provide a valid email address"
+            first_name:
+              blank: "Please enter your first name"
+            last_name:
+              blank: "Please enter your last name"
+            password:
+              too_short: "The password needs to be between 6-10 characters"
+              too_long: "The password needs to be between 6-10 characters"
+              blank: "Password must exists"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,5 +29,30 @@
 # To learn more, please read the Rails Internationalization guide
 # available at http://guides.rubyonrails.org/i18n.html.
 
+
+# This is a yaml file that is loaded by rails, it lets you use translate your
+# define texts in a different language. In our case we are using it to customise
+# our messages for our validation checks
 en:
-  hello: "Hello world"
+  session:
+     create:
+       notice: "You have successfully logged in."
+  users:
+     create:
+       notice: "User account was successfully created."
+  activerecord:
+    errors:
+      format: "%{message}"
+      models:
+        user:
+          attributes:
+            email:
+              taken: "This email address has already been used."
+              invalid: "Please enter a valid email address."
+            first_name:
+              blank: "What's your first name."
+            last_name:
+              blank: "What's your last name."
+            password:
+              too_short: "The password needs to be between 6-10 characters."
+              too_long: "The password needs to be between 6-10 characters."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,7 +28,11 @@
 #
 # To learn more, please read the Rails Internationalization guide
 # available at http://guides.rubyonrails.org/i18n.html.
-#
+
+
+# This is a yaml file that is loaded by rails, it lets you use translate your
+# define texts in a different language. In our case we are using it to customise
+# our messages for our validation checks
 en:
   activerecord:
     errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,8 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   # get "session/create"
   resources :posts, :session, :users
+
+
+  get '/' => 'users#new'
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
 
   get '/' => 'users#new'
 
+
 end

--- a/spec/features/user_can_sign_in_spec.rb
+++ b/spec/features/user_can_sign_in_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Session/ Sign-in", type: :feature do
 
   scenario "A user can go to sign up page" do
     path_to_the_sign_in
-    click_link("Sign up for Keeping it rails")
+    click_link("Sign up for Acebook")
     expect(page).to have_content("First name")
   end
 end

--- a/spec/features/user_can_sign_in_spec.rb
+++ b/spec/features/user_can_sign_in_spec.rb
@@ -7,28 +7,30 @@ RSpec.feature "Session/ Sign-in", type: :feature do
   end
 
   scenario "A user can sign in with valid credentials" do
-    visit "/"
+    visit "/session/new"
     fill_in :email, with: "test_email@keepingitrails.com"
     fill_in :password, with: "pa55w0rd"
     click_button "Log In"
     expect(page).to have_content("Welcome test_first_name")
   end
 
-  scenario "A user signs in with invalid email address" do
+  #not implementing the below feature in this commit:
 
-    visit "/"
-    fill_in :email, with: "test_email_other@gmail.com"
-    fill_in :password, with: "pa55w0rd"
-    click_button "Log In"
-    expect(page).to raise_error("Sorry, we do not recognise this email address")
-  end
-
-  scenario "A user signs in with incorrect password" do
-
-    visit "/"
-    fill_in :email, with: "test_email@keepingitrails.com"
-    fill_in :password, with: "incorrect password"
-    click_button "Log In"
-    expect(page).to raise_error("Sorry, please check your password and try again")
-  end
+  # scenario "A user signs in with invalid email address" do
+  #
+  #   visit "/session/new"
+  #   fill_in :email, with: "test_email_other@gmail.com"
+  #   fill_in :password, with: "pa55w0rd"
+  #   click_button "Log In"
+  #   expect(page).to have_content("Sorry, we do not recognise this email address")
+  # end
+  #
+  # scenario "A user signs in with incorrect password" do
+  #
+  #   visit "/session/new"
+  #   fill_in :email, with: "test_email@keepingitrails.com"
+  #   fill_in :password, with: "incorrect password"
+  #   click_button "Log In"
+  #   expect(page).to have_content("Sorry, please check your password and try again")
+  # end
 end

--- a/spec/features/user_can_sign_in_spec.rb
+++ b/spec/features/user_can_sign_in_spec.rb
@@ -7,31 +7,19 @@ RSpec.feature "Session/ Sign-in", type: :feature do
   end
 
   scenario "A user can sign in with valid credentials" do
-    visit '/'
-    click_link "Already a User?"
-    fill_in :email, with: "test_email@keepingitrails.com"
-    fill_in :password, with: "pa55w0rd"
-    click_button "Log In"
+    successful_sign_in
     expect(page).to have_content("Welcome test_first_name")
   end
 
   # not implementing the below feature in this commit:
 
   scenario "A user signs in with invalid email address" do
-    visit '/'
-    click_link "Already a User?"
-    fill_in :email, with: "test_email_other@gmail.com"
-    fill_in :password, with: "pa55w0rd"
-    click_button "Log In"
+    unsuccessful_sign_in_with_wrong_email
     expect(page).to have_content("Sorry, we do not recognise this email address")
   end
 
   scenario "A user signs in with incorrect password" do
-    visit '/'
-    click_link "Already a User?"
-    fill_in :email, with: "test_email@keepingitrails.com"
-    fill_in :password, with: "incorrect password"
-    click_button "Log In"
+    unsuccessful_sign_in_with_wrong_password
     expect(page).to have_content("Sorry, please check your password and try again")
   end
 end

--- a/spec/features/user_can_sign_in_spec.rb
+++ b/spec/features/user_can_sign_in_spec.rb
@@ -7,30 +7,31 @@ RSpec.feature "Session/ Sign-in", type: :feature do
   end
 
   scenario "A user can sign in with valid credentials" do
-    visit "/session/new"
+    visit '/'
+    click_link "Already a User?"
     fill_in :email, with: "test_email@keepingitrails.com"
     fill_in :password, with: "pa55w0rd"
     click_button "Log In"
     expect(page).to have_content("Welcome test_first_name")
   end
 
-  #not implementing the below feature in this commit:
+  # not implementing the below feature in this commit:
 
-  # scenario "A user signs in with invalid email address" do
-  #
-  #   visit "/session/new"
-  #   fill_in :email, with: "test_email_other@gmail.com"
-  #   fill_in :password, with: "pa55w0rd"
-  #   click_button "Log In"
-  #   expect(page).to have_content("Sorry, we do not recognise this email address")
-  # end
-  #
-  # scenario "A user signs in with incorrect password" do
-  #
-  #   visit "/session/new"
-  #   fill_in :email, with: "test_email@keepingitrails.com"
-  #   fill_in :password, with: "incorrect password"
-  #   click_button "Log In"
-  #   expect(page).to have_content("Sorry, please check your password and try again")
-  # end
+  scenario "A user signs in with invalid email address" do
+    visit '/'
+    click_link "Already a User?"
+    fill_in :email, with: "test_email_other@gmail.com"
+    fill_in :password, with: "pa55w0rd"
+    click_button "Log In"
+    expect(page).to have_content("Sorry, we do not recognise this email address")
+  end
+
+  scenario "A user signs in with incorrect password" do
+    visit '/'
+    click_link "Already a User?"
+    fill_in :email, with: "test_email@keepingitrails.com"
+    fill_in :password, with: "incorrect password"
+    click_button "Log In"
+    expect(page).to have_content("Sorry, please check your password and try again")
+  end
 end

--- a/spec/features/user_can_sign_in_spec.rb
+++ b/spec/features/user_can_sign_in_spec.rb
@@ -8,18 +8,23 @@ RSpec.feature "Session/ Sign-in", type: :feature do
 
   scenario "A user can sign in with valid credentials" do
     successful_sign_in
+    expect(page).to have_content("You have successfully logged in.")
     expect(page).to have_content("Welcome test_first_name")
   end
 
-  # not implementing the below feature in this commit:
-
   scenario "A user signs in with invalid email address" do
     unsuccessful_sign_in_with_wrong_email
-    expect(page).to have_content("Sorry, we do not recognise this email address")
+    expect(page).to have_content("The email address that you've entered doesn't match an account.")
   end
 
   scenario "A user signs in with incorrect password" do
     unsuccessful_sign_in_with_wrong_password
-    expect(page).to have_content("Sorry, please check your password and try again")
+    expect(page).to have_content("The password that you've entered is incorrect.")
+  end
+
+  scenario "A user can go to sign up page" do
+    path_to_the_sign_in
+    click_link("Sign up for Keeping it rails")
+    expect(page).to have_content("First name")
   end
 end

--- a/spec/features/user_can_sign_up_spec.rb
+++ b/spec/features/user_can_sign_up_spec.rb
@@ -4,21 +4,48 @@ RSpec.feature "SignUp", type: :feature do
 
     scenario "A user can sign up with valid credentials" do
       successful_sign_up
-      expect(page).to have_content("Welcome test_first_name!")
+      expect(page).to have_content("User account was successfully created.")
+      expect(page).to have_content("Welcome test_first_name")
     end
 
     scenario "A user provides an password with less than 6 characters" do
       unsuccessful_sign_up_with_wrong_password
       fill_in 'Password', with: "pass"
       click_button "Sign Up"
-      expect(page).to have_content("The password needs to be between 6-10 characters")
+      expect(page).to have_content("The password needs to be between 6-10 characters.")
     end
 
     scenario "A user provides an password with more than 10 characters" do
       unsuccessful_sign_up_with_wrong_password
       fill_in 'Password', with: "passWordthatismorethan10Char"
       click_button "Sign Up"
-      expect(page).to have_content("The password needs to be between 6-10 characters")
+      expect(page).to have_content("The password needs to be between 6-10 characters.")
+    end
+
+    scenario "A user does not provide a first name" do
+      unsuccessful_sign_up_without_first_name
+      expect(page).to have_content("What's your first name.")
+    end
+
+    scenario "A user does not provide a last name" do
+      unsuccessful_sign_up_without_last_name
+      expect(page).to have_content("What's your last name.")
+    end
+
+    scenario "A user does not provide an email address" do
+      unsuccessful_sign_up_without_email
+      expect(page).to have_content("Please enter a valid email address")
+    end
+
+    scenario "A user provides an email already taken" do
+      successful_sign_up
+      successful_sign_up
+      expect(page).to have_content("This email address has already been used")
+    end
+
+    scenario "A user does not provide a valid email address format" do
+      unsuccessful_sign_up_with_wrong_email_format
+      expect(page).to have_content("Please enter a valid email address")
     end
 
 end

--- a/spec/features/user_can_sign_up_spec.rb
+++ b/spec/features/user_can_sign_up_spec.rb
@@ -7,4 +7,18 @@ RSpec.feature "SignUp", type: :feature do
       expect(page).to have_content("Welcome test_first_name!")
     end
 
+    scenario "A user provides an password with less than 6 characters" do
+      unsuccessful_sign_up_with_wrong_password
+      fill_in 'Password', with: "pass"
+      click_button "Sign Up"
+      expect(page).to have_content("The password needs to be between 6-10 characters")
+    end
+
+    scenario "A user provides an password with more than 10 characters" do
+      unsuccessful_sign_up_with_wrong_password
+      fill_in 'Password', with: "passWordthatismorethan10Characters"
+      click_button "Sign Up"
+      expect(page).to have_content("The password needs to be between 6-10 characters")
+    end
+
 end

--- a/spec/features/user_can_sign_up_spec.rb
+++ b/spec/features/user_can_sign_up_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "SignUp", type: :feature do
 
     scenario "A user provides an password with more than 10 characters" do
       unsuccessful_sign_up_with_wrong_password
-      fill_in 'Password', with: "passWordthatismorethan10Characters"
+      fill_in 'Password', with: "passWordthatismorethan10Char"
       click_button "Sign Up"
       expect(page).to have_content("The password needs to be between 6-10 characters")
     end

--- a/spec/features/user_can_sign_up_spec.rb
+++ b/spec/features/user_can_sign_up_spec.rb
@@ -21,4 +21,52 @@ RSpec.feature "SignUp", type: :feature do
       expect(page).to have_content("The password needs to be between 6-10 characters")
     end
 
+    scenario "A user does not provide a first name" do
+      visit "/"
+      fill_in 'Last name', with: "test_last_name"
+      fill_in 'Email', with: "test_email@keepingitrails.com"
+      fill_in 'Password', with: "pa55w0rd"
+      click_button "Sign Up"
+      expect(page).to have_content("Please enter your first name")
+    end
+
+    scenario "A user does not provide a last name" do
+      visit "/"
+      fill_in 'First name', with: "test_first_name"
+      fill_in 'Email', with: "test_email@keepingitrails.com"
+      fill_in 'Password', with: "pa55w0rd"
+      click_button "Sign Up"
+      expect(page).to have_content("Please enter your last name")
+    end
+
+    scenario "A user does not provide an email address" do
+      visit "/"
+      fill_in 'First name', with: "test_first_name"
+      fill_in 'Last name', with: "test_last_name"
+      fill_in 'Password', with: "pa55w0rd"
+      click_button "Sign Up"
+      expect(page).to have_content("Please enter an email address")
+    end
+
+    scenario "A user provides an email already taken" do
+      successful_sign_up
+      visit "/"
+      fill_in 'First name', with: "test_first_name"
+      fill_in 'Last name', with: "test_last_name"
+      fill_in 'Email', with: "test_email@keepingitrails.com"
+      fill_in 'Password', with: "pa55w0rd"
+      click_button "Sign Up"
+      expect(page).to have_content("This email address has already been used")
+    end
+
+    scenario "A user does not provide a valid email address format" do
+      visit "/"
+      fill_in 'First name', with: "test_first_name"
+      fill_in 'Last name', with: "test_last_name"
+      fill_in 'Email', with: "wrongformat"
+      fill_in 'Password', with: "pa55w0rd"
+      click_button "Sign Up"
+      expect(page).to have_content("Please provide a valid email address")
+    end
+
 end

--- a/spec/features/web_helper.rb
+++ b/spec/features/web_helper.rb
@@ -72,5 +72,5 @@ end
 
 def path_to_the_sign_in
   visit "/"
-  click_link "Already a User?"
+  click_link "Already have an Acebook account?"
 end

--- a/spec/features/web_helper.rb
+++ b/spec/features/web_helper.rb
@@ -1,8 +1,15 @@
 def successful_sign_up
-  visit "/users/new"
+  visit "/"
   fill_in 'First name', with: "test_first_name"
   fill_in 'Last name', with: "test_last_name"
   fill_in 'Email', with: "test_email@keepingitrails.com"
   fill_in 'Password', with: "pa55w0rd"
   click_button "Sign Up"
+end
+
+def unsuccessful_sign_up_with_wrong_password
+  visit "/"
+  fill_in 'First name', with: "test_first_name"
+  fill_in 'Last name', with: "test_last_name"
+  fill_in 'Email', with: "test_email@keepingitrails.com"
 end

--- a/spec/features/web_helper.rb
+++ b/spec/features/web_helper.rb
@@ -15,6 +15,38 @@ def unsuccessful_sign_up_with_wrong_password
   fill_in 'Email', with: "test_email@keepingitrails.com"
 end
 
+def unsuccessful_sign_up_without_first_name
+  visit "/"
+  fill_in 'Last name', with: "test_last_name"
+  fill_in 'Email', with: "test_email@keepingitrails.com"
+  fill_in 'Password', with: "pa55w0rd"
+  click_button "Sign Up"
+end
+
+def unsuccessful_sign_up_without_last_name
+  visit "/"
+  fill_in 'First name', with: "test_first_name"
+  fill_in 'Email', with: "test_email@keepingitrails.com"
+  fill_in 'Password', with: "pa55w0rd"
+  click_button "Sign Up"
+end
+
+def unsuccessful_sign_up_without_email
+  visit "/"
+  fill_in 'First name', with: "test_first_name"
+  fill_in 'Last name', with: "test_last_name"
+  fill_in 'Password', with: "pa55w0rd"
+  click_button "Sign Up"
+end
+
+def unsuccessful_sign_up_with_wrong_email_format
+  visit "/"
+  fill_in 'First name', with: "test_first_name"
+  fill_in 'Last name', with: "test_last_name"
+  fill_in 'Email', with: "wrongformat"
+  fill_in 'Password', with: "pas55w0rd"
+  click_button "Sign Up"
+end
 
 #sign in
 def successful_sign_in

--- a/spec/features/web_helper.rb
+++ b/spec/features/web_helper.rb
@@ -18,25 +18,27 @@ end
 
 #sign in
 def successful_sign_in
-  visit "/"
-  click_link "Already a User?"
+  path_to_the_sign_in
   fill_in 'Email', with: "test_email@keepingitrails.com"
   fill_in 'Password', with: "pa55w0rd"
   click_button "Log In"
 end
 
 def unsuccessful_sign_in_with_wrong_email
-  visit "/"
-  click_link "Already a User?"
+  path_to_the_sign_in
   fill_in 'Email', with: "test_email_other@gmail.com"
   fill_in 'Password', with: "pa55w0rd"
   click_button "Log In"
 end
 
 def unsuccessful_sign_in_with_wrong_password
-  visit "/"
-  click_link "Already a User?"
+  path_to_the_sign_in
   fill_in 'Email', with: "test_email@keepingitrails.com"
   fill_in 'Password', with: "incorrect password"
   click_button "Log In"
+end
+
+def path_to_the_sign_in
+  visit "/"
+  click_link "Already a User?"
 end

--- a/spec/features/web_helper.rb
+++ b/spec/features/web_helper.rb
@@ -1,3 +1,4 @@
+#sign up
 def successful_sign_up
   visit "/"
   fill_in 'First name', with: "test_first_name"
@@ -12,4 +13,30 @@ def unsuccessful_sign_up_with_wrong_password
   fill_in 'First name', with: "test_first_name"
   fill_in 'Last name', with: "test_last_name"
   fill_in 'Email', with: "test_email@keepingitrails.com"
+end
+
+
+#sign in
+def successful_sign_in
+  visit "/"
+  click_link "Already a User?"
+  fill_in 'Email', with: "test_email@keepingitrails.com"
+  fill_in 'Password', with: "pa55w0rd"
+  click_button "Log In"
+end
+
+def unsuccessful_sign_in_with_wrong_email
+  visit "/"
+  click_link "Already a User?"
+  fill_in 'Email', with: "test_email_other@gmail.com"
+  fill_in 'Password', with: "pa55w0rd"
+  click_button "Log In"
+end
+
+def unsuccessful_sign_in_with_wrong_password
+  visit "/"
+  click_link "Already a User?"
+  fill_in 'Email', with: "test_email@keepingitrails.com"
+  fill_in 'Password', with: "incorrect password"
+  click_button "Log In"
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+
+
   it { is_expected.to be }
 
   describe '#authenticate' do
@@ -15,6 +17,19 @@ RSpec.describe User, type: :model do
       expect(user.authenticate("wrong_pa55w0rd")).to be_falsey
     end
 
+  end
+
+  describe '#create' do
+
+    it 'returns false if given email address not in database' do
+      user = User.create(first_name: "test_first_name", last_name: "test_last_name", email: "test_email@keepingitrails.com", password: "pa55w0rd")
+      expect(User.exists?(email: "jeff@keepingitrails.com")).to be_falsey
+    end
+
+    it 'returns true if given email address is in database' do
+      user = User.create(first_name: "test_first_name", last_name: "test_last_name", email: "test_email@keepingitrails.com", password: "pa55w0rd")
+      expect(User.exists?(email: "test_email@keepingitrails.com")).to be_truthy
+    end
   end
 
 end


### PR DESCRIPTION
-Added validation checks so:
a) all fields are filled in the sign up form
b) password must be between 6-10 characters
c) email must be in the correct format
d) user cannot enter an email address already in the database

-introduced some code in the en.yml file customise validation messages
-changed the route to be the sign up form
-updated view to show messages from the yaml file to the user